### PR TITLE
Ajouter le label manquant sur le bouton de division (/)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
          <button type="button" class="btn" onclick="clearDisplay()">C</button>
          <!-- Le bouton « = » est de type submit pour déclencher l'envoi du formulaire -->
          <button type="submit" class="btn operator">=</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
       </div>
    </form>
 </div>


### PR DESCRIPTION
Cette pull request corrige le problème d’affichage dans l’interface utilisateur où le contenu du bouton de division est vide.

Le texte du bouton a été corrigé dans templates/index.html afin d’assurer un affichage cohérent et conforme à la valeur attendue, soit l'opérateur / représentant la division.

#7 